### PR TITLE
Update solution.pl

### DIFF
--- a/67/solution.pl
+++ b/67/solution.pl
@@ -1,3 +1,3 @@
 #!perl -n
 use 5.010;
-say hex;
+say hex while <>;


### PR DESCRIPTION
Using the `-n` flag in the shebang line leads to poor readability and ultimately contributes to the heat-death of the universe.
